### PR TITLE
Fixed: Help field not initialized in options class constructor

### DIFF
--- a/include/redmine.h
+++ b/include/redmine.h
@@ -45,7 +45,7 @@ enum result {
 /// @brief Object encapsulating all command line options.
 struct options {
   /// @brief Default constructor.
-  options() : verbose(), debug(), debug_http() {}
+  options() : help(), verbose(), debug(), debug_http() {}
 
   /// @breif Option to display help output.
   bool help;


### PR DESCRIPTION
The help member of the option class was not initialized, dumping garbage when building on Debug in GCC and forcing the main program to display the help and exit always.
This trivial patch fixes the issue.